### PR TITLE
Reduce testing on staging

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        node-version: [10.x, 12.x, 13.x]
+        node-version: [12.x, 13.x]
 
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
This PR will remove the Node 8 and macOS tests and stop testing on every single push. It won't strictly affect staging too much, but will stop people needing to adjust the testing configs on their feature branches after merging staging into them.

Due to the high priority of this PR, please merge it as soon as it's been approved.