### PR TITLE
Merge db-indexing-fix into staging; resolves #71

### DIFF
--- a/src/core/WarehouseModel.ts
+++ b/src/core/WarehouseModel.ts
@@ -145,16 +145,16 @@ async function generateRandomWarehouse(id: string, name: string): Promise<Wareho
         const zone = Zone.create(zoneFields.name, zoneFields.color, warehouse);
 
         for (let j = 0; j < 5; j++) {
-            const bay = Bay.create(j, String.fromCharCode(65 + j), zone);
+            const bay = Bay.create(String.fromCharCode(65 + j), zone);
 
             for (let k = 0; k < 5; k++) {
-                const shelf = Shelf.create(k, `${k + 1}`, k === 1, bay);
+                const shelf = Shelf.create(`${k + 1}`, k === 1, bay);
 
                 for (let l = 0; l < 4; l++) {
-                    const column = Column.create(l, warehouse.defaultTraySize, 3, shelf);
+                    const column = Column.create(warehouse.defaultTraySize, 3, shelf);
 
                     for (let m = 0; m < 3; m++) {
-                        makeRandomTray(column, m);
+                        makeRandomTray(column);
                     }
                 }
             }
@@ -165,29 +165,29 @@ async function generateRandomWarehouse(id: string, name: string): Promise<Wareho
         const zone = Zone.create(zoneFields.name, zoneFields.color, warehouse);
 
         for (let j = 0; j < 2; j++) {
-            const bay = Bay.create(j, String.fromCharCode(65 + j), zone);
+            const bay = Bay.create(String.fromCharCode(65 + j), zone);
 
             for (let k = 0; k < 4; k++) {
-                const shelf = Shelf.create(k, `${k + 1}`, false, bay);
+                const shelf = Shelf.create(`${k + 1}`, false, bay);
 
                 for (let l = 0; l < 4; l++) {
-                    const column = Column.create(l, warehouse.defaultTraySize, 3, shelf);
+                    const column = Column.create(warehouse.defaultTraySize, 3, shelf);
 
                     for (let m = 0; m < 3; m++) {
-                        makeRandomTray(column, m);
+                        makeRandomTray(column);
                     }
                 }
             }
         }
     }
 
-    function makeRandomTray(parentColumn: Column, index: number): void {
+    function makeRandomTray(parentColumn: Column): void {
         const category = Math.random() < 0.25 ? undefined : Utils.randItem(warehouse.categories);
         const expiry = Math.random() < 0.25 ? undefined : Utils.randItem(trayExpires);
         const weight = Math.random() < 0.25 ? undefined :
                        Number((15 * Math.random()).toFixed(2));
 
-        Tray.create(parentColumn, index, category, expiry, weight,
+        Tray.create(parentColumn, category, expiry, weight,
             Math.random() < 0.1 ? "This is a custom comment, it might be very long" : undefined);
     }
 

--- a/src/core/WarehouseModel/LayerStructure/BottomLayer.ts
+++ b/src/core/WarehouseModel/LayerStructure/BottomLayer.ts
@@ -33,7 +33,7 @@ export abstract class BottomLayer<TParent extends UpperLayer, TFields> extends L
     /**
      * Get the index of the object within its parent's collection
      */
-    public get indexInParent(): number {
+    public get index(): number {
         return this.parent.getChildIndex(this);
     }
 
@@ -56,12 +56,23 @@ export abstract class BottomLayer<TParent extends UpperLayer, TFields> extends L
     }
 
     public async delete(commit = false): Promise<void> {
-        this.parent.children.splice(this.indexInParent, 1);
+        this.parent.children.splice(this.index, 1);
 
         firebase.database.delete(this.topLevelPath);
 
         if (commit) {
             await firebase.database.commit();
+        }
+    }
+
+    protected stageLayer(forceStage = false): void {
+        if (this.changed || forceStage) {
+            firebase.database.set(this.topLevelPath, {
+                ...this.fields,
+                layerIdentifiers: this.layerIdentifiers,
+                index: this.index,
+            });
+            this.fieldsSaved();
         }
     }
 

--- a/src/core/WarehouseModel/LayerStructure/Layer.ts
+++ b/src/core/WarehouseModel/LayerStructure/Layer.ts
@@ -74,15 +74,7 @@ export abstract class Layer<TFields> extends DatabaseObject<TFields> {
      */
     public abstract bfs(callback: (layer: Layers) => void): void;
 
-    protected stageLayer(forceStage = false): void {
-        if (this.changed || forceStage) {
-            firebase.database.set(this.topLevelPath, {
-                ...this.fields,
-                layerIdentifiers: this.layerIdentifiers
-            });
-            this.fieldsSaved();
-        }
-    }
+    protected abstract stageLayer(forceStage: boolean): void;
 
     protected async loadLayer(forceLoad = true): Promise<this> {
         if (!this.loaded || forceLoad) {

--- a/src/core/WarehouseModel/Layers/Bay.ts
+++ b/src/core/WarehouseModel/Layers/Bay.ts
@@ -3,23 +3,20 @@ import {MiddleLayer} from "../LayerStructure/MiddleLayer";
 import Utils from "../Utils";
 
 interface BayFields {
-    index: number;
     name: string;
 }
 
 export class Bay extends MiddleLayer<Zone, BayFields, Shelf> {
     public readonly layerID: WarehouseModel = WarehouseModel.bay;
-    public readonly childIndexed = true;
     public readonly collectionName = "bays";
     public readonly childCollectionName = "shelves";
 
     /**
      * @param name - The name of the bay
-     * @param index - The (ordered) index of the bay within the zone
      * @param parent - The parent zone
      */
-    public static create(index: number, name: string, parent: Zone): Bay {
-        return new Bay(Utils.generateRandomId(), {index, name}, parent);
+    public static create(name: string, parent: Zone): Bay {
+        return new Bay(Utils.generateRandomId(), {name}, parent);
     }
 
     /**
@@ -37,14 +34,6 @@ export class Bay extends MiddleLayer<Zone, BayFields, Shelf> {
     public createChild = Shelf.createFromFields;
 
     //#region Field Getters and Setters
-    public get index(): number {
-        return this.fields.index;
-    }
-
-    public set index(index: number) {
-        this.fields.index = index;
-    }
-
     public get name(): string {
         return this.fields.name;
     }

--- a/src/core/WarehouseModel/Layers/Column.ts
+++ b/src/core/WarehouseModel/Layers/Column.ts
@@ -3,14 +3,12 @@ import {MiddleLayer} from "../LayerStructure/MiddleLayer";
 import Utils from "../Utils";
 
 interface ColumnFields {
-    index: number;
     traySizeId: string;
     maxHeight: number;
 }
 
 export class Column extends MiddleLayer<Shelf, ColumnFields, Tray> {
     public readonly layerID: WarehouseModel = WarehouseModel.column;
-    public readonly childIndexed = true;
     public readonly collectionName = "columns";
     public readonly childCollectionName = "trays";
 
@@ -21,14 +19,12 @@ export class Column extends MiddleLayer<Shelf, ColumnFields, Tray> {
     private static traySpaces: Map<Column, TraySpace[]> = new Map<Column, TraySpace[]>();
 
     /**
-     * @param index - The (ordered) index of the column within the shelf
      * @param traySize - The size of the tray
      * @param maxHeight - The maximum number of trays that can be placed in this column
      * @param parent - The parent shelf
      */
-    public static create(index: number, traySize: TraySize, maxHeight: number, parent: Shelf): Column {
+    public static create(traySize: TraySize, maxHeight: number, parent: Shelf): Column {
         return new Column(Utils.generateRandomId(), {
-            index,
             traySizeId: parent.parentWarehouse.getTraySizeId(traySize),
             maxHeight
         }, parent);
@@ -49,14 +45,6 @@ export class Column extends MiddleLayer<Shelf, ColumnFields, Tray> {
     }
 
     //#region Field Getters and Setters
-    public get index(): number {
-        return this.fields.index;
-    }
-
-    public set index(index: number) {
-        this.fields.index = index;
-    }
-
     public get traySize(): TraySize | undefined {
         return this.parentWarehouse.getTraySizeByID(this.fields.traySizeId);
     }

--- a/src/core/WarehouseModel/Layers/Shelf.ts
+++ b/src/core/WarehouseModel/Layers/Shelf.ts
@@ -3,25 +3,22 @@ import {MiddleLayer} from "../LayerStructure/MiddleLayer";
 import Utils from "../Utils";
 
 interface ShelfFields {
-    index: number;
     name: string;
     isPickingArea: boolean;
 }
 
 export class Shelf extends MiddleLayer<Bay, ShelfFields, Column> {
     public readonly layerID: WarehouseModel = WarehouseModel.shelf;
-    public readonly childIndexed = true;
     public readonly collectionName = "shelves";
     public readonly childCollectionName = "columns";
 
     /**
-     * @param index - The (ordered) index of the shelf within the bay
      * @param name - The name of the shelf
      * @param isPickingArea - true if in picking area
      * @param parent - The parent bay
      */
-    public static create(index: number, name: string, isPickingArea: boolean, parent: Bay): Shelf {
-        return new Shelf(Utils.generateRandomId(), {index, name, isPickingArea}, parent);
+    public static create(name: string, isPickingArea: boolean, parent: Bay): Shelf {
+        return new Shelf(Utils.generateRandomId(), {name, isPickingArea}, parent);
     }
 
     /**
@@ -39,14 +36,6 @@ export class Shelf extends MiddleLayer<Bay, ShelfFields, Column> {
     }
 
     //#region Field Getters and Setters
-    public get index(): number {
-        return this.fields.index;
-    }
-
-    public set index(index: number) {
-        this.fields.index = index;
-    }
-
     public get name(): string {
         return this.fields.name;
     }

--- a/src/core/WarehouseModel/Layers/Tray.ts
+++ b/src/core/WarehouseModel/Layers/Tray.ts
@@ -3,7 +3,6 @@ import {BottomLayer} from "../LayerStructure/BottomLayer";
 import Utils from "../Utils";
 
 interface TrayFields {
-    index: number;
     categoryId: string;
     expiry: ExpiryRange | null;
     weight: number | null;
@@ -16,17 +15,15 @@ export class Tray extends BottomLayer<Column, TrayFields> {
 
     /**
      * @param parent - The (nullable) parent column
-     * @param index - The index of the tray within the column
      * @param category - The tray's (nullable) category
      * @param expiry - The tray's (nullable) expiry range
      * @param weight - The tray's (nullable) weight
      * @param comment - The tray's (nullable) custom comment
      */
-    public static create(parent: Column, index: number, category?: Category, expiry?: ExpiryRange, weight?: number,
+    public static create(parent: Column, category?: Category, expiry?: ExpiryRange, weight?: number,
                          comment?: string
     ): Tray {
         return new Tray(Utils.generateRandomId(), {
-            index,
             categoryId: parent.parentWarehouse.getCategoryID(category),
             expiry: expiry ?? null,
             weight: weight ?? null,
@@ -47,14 +44,6 @@ export class Tray extends BottomLayer<Column, TrayFields> {
     }
 
     //#region Field Getters and Setters
-    public get index(): number {
-        return this.fields.index;
-    }
-
-    public set index(index: number) {
-        this.fields.index = index;
-    }
-
     public get category(): Category | undefined {
         return this.parentWarehouse.getCategoryByID(this.fields.categoryId);
     }
@@ -115,15 +104,15 @@ export class Tray extends BottomLayer<Column, TrayFields> {
     //region derived properties
     public get locationString(): string {
         return `${
-            this.parentZone.indexInParent
+            this.parentZone.index
         }_${
-            this.parentBay.indexInParent
+            this.parentBay.index
         }_${
-            this.parentShelf.indexInParent
+            this.parentShelf.index
         }_${
-            this.parentColumn.indexInParent
+            this.parentColumn.index
         }_${
-            this.indexInParent
+            this.index
         }`;
     }
 

--- a/src/core/WarehouseModel/Layers/Zone.ts
+++ b/src/core/WarehouseModel/Layers/Zone.ts
@@ -10,7 +10,6 @@ interface ZoneFields {
 
 export class Zone extends MiddleLayer<Warehouse, ZoneFields, Bay> {
     public readonly layerID: WarehouseModel = WarehouseModel.zone;
-    public readonly childIndexed = true;
     public readonly collectionName = "zones";
     public readonly childCollectionName = "bays";
 

--- a/src/pages/ShelfViewPage.tsx
+++ b/src/pages/ShelfViewPage.tsx
@@ -208,7 +208,7 @@ class ShelfViewPage extends React.Component<RouteComponentProps & ShelfViewProps
                 currentZone: Zone = currentBay.parent,
                 shelfIndex: number = currentShelf.index,
                 bayIndex: number = currentBay.index,
-                zoneIndex: number = currentZone.indexInParent;
+                zoneIndex: number = currentZone.index;
 
             if (direction === "up" || direction === "down") { // vertical
 
@@ -378,7 +378,6 @@ class ShelfViewPage extends React.Component<RouteComponentProps & ShelfViewProps
                 if (!ignoreAirSpaces || space.index === space.parentColumn.trays.length) {
                     const newTray = Tray.create(
                         space.parentColumn,
-                        space.index,
                         undefined,
                         undefined,
                         undefined);
@@ -425,7 +424,7 @@ class ShelfViewPage extends React.Component<RouteComponentProps & ShelfViewProps
     private advanceSelection(canGoToCell: boolean, selection: Map<TrayCell, boolean>): Map<TrayCell, boolean> {
 
         const comparison = composeSorts<TrayCell>([
-            byNullSafe<TrayCell>(cell => cell.parentColumn.indexInParent, false, false),
+            byNullSafe<TrayCell>(cell => cell.parentColumn.index, false, false),
             byNullSafe<TrayCell>(cell => cell.index, false, false)
         ]);
 
@@ -600,7 +599,6 @@ class ShelfViewPage extends React.Component<RouteComponentProps & ShelfViewProps
      */
     private addColumn(shelf: Shelf): void {
         Column.create(
-            shelf.columns.length,
             this.props.warehouse.defaultTraySize,
             3,
             shelf
@@ -684,10 +682,6 @@ class ShelfViewPage extends React.Component<RouteComponentProps & ShelfViewProps
                     tray.delete(true);
                 }
             }
-        });
-
-        reindexColumns.forEach((column) => {
-            column.trays.forEach((tray, index) => tray.index = index);
         });
 
         this.setSelected(newSelectedMap);


### PR DESCRIPTION
As per the commit:

I've been silly and forgotten to re-index layers that have an index field when others in their collection have been deleted, this means everything goes quickly out of sync.
To fix I have now made it so that each LowerLayer must have an index which is sorted by in the database (and placed into the local structure in the correct order), as such the index field has been removed from each layer (hence index is no longer settable and just returns what indexInParent used to return). When layers are saved to the database the index within its parent is saved as its database index.