### PR TITLE
Disable browser gestures

### DIFF
--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -9,8 +9,9 @@ body {
   -moz-osx-font-smoothing: grayscale;
 
   /* Disables pull-to-refresh and overscroll glow effect.
-     Still keeps swipe navigations. */
+     Also disables back/forward swipe gestures. */
   overscroll-behavior-y: none;
+  overscroll-behavior-x: none;
 }
 
 button:not(.btn-style-override), input[type="submit"] {


### PR DESCRIPTION
Should hopefully disable Android's pull-to-refresh, and the forward/back swipe gestures too.

Pls test this on any devices you can!